### PR TITLE
dird migration: remove the version check

### DIFF
--- a/post-start.d/26-dird-auto-create-config.py
+++ b/post-start.d/26-dird-auto-create-config.py
@@ -2,7 +2,6 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import argparse
 import os
 import sys
 import requests
@@ -219,12 +218,6 @@ def _auto_create_config():
 
 
 def main():
-    args = parse_args()
-    if not args.force:
-        version_installed = os.getenv('XIVO_VERSION_INSTALLED')
-        if version_installed >= '19.08':
-            sys.exit(0)
-
     sentinel_file = '/var/lib/xivo-upgrade/dird-auto-create-config-v3'
     if os.path.exists(sentinel_file):
         # migration already done
@@ -234,17 +227,6 @@ def main():
 
     with open(sentinel_file, 'w'):
         pass
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-f',
-        '--force',
-        action='store_true',
-        help="Do not check the variable XIVO_VERSION_INSTALLED. Default: %(default)s",
-    )
-    return parser.parse_args()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
the version prevents the script to be executed if it did not get executed on
the upgrade from < 19.08.

removing the check will allow the script to be executed if the administrator
re-starts wazo-upgrade to fix the upgrade

the script is meant to be executed multiple times, if all the resource already
exits the script will still complete successfully.